### PR TITLE
Fix -1 max concurrent downloads sentinel

### DIFF
--- a/backend/downloader.js
+++ b/backend/downloader.js
@@ -21,6 +21,14 @@ let should_check_downloads = true;
 
 const download_to_child_process = {};
 
+function hasReachedConcurrentDownloadLimit(maxConcurrentDownloads, runningDownloadsCount) {
+    const normalizedLimit = Number(maxConcurrentDownloads);
+    // `-1` (and other negative values) mean "no limit" in the UI/config.
+    if (!Number.isFinite(normalizedLimit) || normalizedLimit < 0) return false;
+    return runningDownloadsCount >= normalizedLimit;
+}
+exports.hasReachedConcurrentDownloadLimit = hasReachedConcurrentDownloadLimit;
+
 if (db_api.database_initialized) {
     exports.setupDownloads();
 } else {
@@ -184,7 +192,7 @@ async function checkDownloads() {
     for (let i = 0; i < waiting_downloads.length; i++) {
         const waiting_download = waiting_downloads[i];
         const max_concurrent_downloads = config_api.getConfigItem('ytdl_max_concurrent_downloads');
-        if (max_concurrent_downloads < 0 || running_downloads_count >= max_concurrent_downloads) break;
+        if (hasReachedConcurrentDownloadLimit(max_concurrent_downloads, running_downloads_count)) break;
 
         if (waiting_download['finished_step'] && !waiting_download['finished']) {
             if (waiting_download['sub_id']) {

--- a/backend/test/tests.js
+++ b/backend/test/tests.js
@@ -584,6 +584,14 @@ describe('Downloader', function() {
         assert(returned_download);
     });
 
+    it('Respect max concurrent downloads sentinel -1', function() {
+        assert.strictEqual(downloader_api.hasReachedConcurrentDownloadLimit(-1, 0), false);
+        assert.strictEqual(downloader_api.hasReachedConcurrentDownloadLimit('-1', 5), false);
+        assert.strictEqual(downloader_api.hasReachedConcurrentDownloadLimit(0, 0), true);
+        assert.strictEqual(downloader_api.hasReachedConcurrentDownloadLimit(1, 0), false);
+        assert.strictEqual(downloader_api.hasReachedConcurrentDownloadLimit(1, 1), true);
+    });
+
     it('Pause file', async function() {
         const returned_download = await downloader_api.createDownload(url, 'video', options);
         await downloader_api.pauseDownload(returned_download['uid']);


### PR DESCRIPTION
## Summary
- Restore `-1` handling for `ytdl_max_concurrent_downloads` so it means no limit
- Make the scheduler limit check explicit to avoid sentinel regressions
- Add a regression test covering `-1` and standard limit behavior

## Testing
- `node --check backend/downloader.js`
- `node --check backend/test/tests.js`

Closes #16
