### PR TITLE
Fix apprise(s) alias routing to /notify endpoint

### DIFF
--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -338,14 +338,32 @@ function parseWebhookURL(webhook_url) {
     }
 
     try {
+        const parsed_url = new URL(request_url);
+        if (explicit_apprise) normalizeAppriseURL(parsed_url);
         return {
-            request_url: request_url,
-            parsed_url: new URL(request_url),
+            request_url: parsed_url.toString(),
+            parsed_url: parsed_url,
             explicit_apprise: explicit_apprise
         };
     } catch {
         return null;
     }
+}
+
+function normalizeAppriseURL(parsed_url) {
+    const key_pattern = /^[\w-]{1,128}$/;
+    const key_from_path = (parsed_url.pathname || '').match(/^\/apprise\/([\w-]{1,128})\/?$/i);
+    const query_key = parsed_url.searchParams.get('key');
+    const key_from_query = query_key && key_pattern.test(query_key) ? query_key : null;
+    const key = key_from_path ? key_from_path[1] : key_from_query;
+
+    const path = (parsed_url.pathname || '/').toLowerCase();
+    const apprise_alias = path === '/' || path === '/apprise' || path === '/apprise/';
+    if (apprise_alias || key_from_path) {
+        parsed_url.pathname = key ? `/notify/${key}` : '/notify';
+    }
+
+    if (key_from_query) parsed_url.searchParams.delete('key');
 }
 
 function mapNotificationTypeToAppriseType(type) {

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -400,7 +400,7 @@
               <mat-form-field class="text-field" color="accent">
                 <mat-label i18n="webhook URL">Webhook URL</mat-label>
                 <input placeholder="https://example.com/endpoint/12345" [(ngModel)]="new_config['API']['webhook_URL']" matInput>
-                <mat-hint>Place endpoint URL here to integrate with services like Zapier, Automatisch, and Apprise (/notify/&lt;key&gt; or apprise(s)://...?...).</mat-hint>
+                <mat-hint>Place endpoint URL here to integrate with services like Zapier, Automatisch, and Apprise (/notify/&lt;key&gt; or apprise(s)://host/apprise?tags=...).</mat-hint>
               </mat-form-field>
             </div>
             <div class="col-12 mb-2 mt-3">


### PR DESCRIPTION
## Summary
- normalize explicit `apprise://` / `apprises://` alias paths to Apprise API's notify endpoint
- rewrite `/apprise` and `/apprise/<key>` into `/notify` and `/notify/<key>`
- support optional query key: `/apprise?key=<key>&tags=...` -> `/notify/<key>?tags=...`

## Why
PR #119 added Apprise webhook support, but explicit alias URLs could still post to `/apprise`, which is not a default Apprise API notify route and returns 404.

This hotfix ensures alias URLs hit valid notify routes.

## Validation
- `node --check backend/notifications.js`
